### PR TITLE
Disable some eslint react rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,6 +28,7 @@
     }
   },
   "rules": {
-    "react/prop-types": 0
+    "react/prop-types": 0,
+    "no-unused-vars": 0
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,5 +26,8 @@
     "react": {
       "version": "detect"
     }
+  },
+  "rules": {
+    "react/prop-types": 0
   }
 }


### PR DESCRIPTION
- Disable `react/props-types` rule. This is not needed since we are using TypeScript.
- Disable `no-unused-vars` rule as it throws an error when just importing types